### PR TITLE
Adding b4: prefix to all snippets

### DIFF
--- a/snippets/components/alerts/danger.sublime-snippet
+++ b/snippets/components/alerts/danger.sublime-snippet
@@ -4,5 +4,5 @@
     ${1:<strong>Warning!</strong> Better check yourself, you're not looking too good.}
 </div>
 ]]></content>
-	<tabTrigger>alert:danger</tabTrigger>
+	<tabTrigger>b4:alert:danger</tabTrigger>
 </snippet>

--- a/snippets/components/alerts/danger_link.sublime-snippet
+++ b/snippets/components/alerts/danger_link.sublime-snippet
@@ -4,5 +4,5 @@
 	${1:<strong>Oh snap!</strong> <a href="#" class="alert-link">Change a few things up</a> and try submitting again.}
 </div>
 ]]></content>
-	<tabTrigger>alert:danger:l</tabTrigger>
+	<tabTrigger>b4:alert:danger:l</tabTrigger>
 </snippet>

--- a/snippets/components/alerts/dismissible.sublime-snippet
+++ b/snippets/components/alerts/dismissible.sublime-snippet
@@ -8,5 +8,5 @@
 	${1:<strong>Holy guacamole!</strong> You should check in on some of those fields below.}
 </div>
 ]]></content>
-	<tabTrigger>alert:dismissible</tabTrigger>
+	<tabTrigger>b4:alert:dismissible</tabTrigger>
 </snippet>

--- a/snippets/components/alerts/info.sublime-snippet
+++ b/snippets/components/alerts/info.sublime-snippet
@@ -4,5 +4,5 @@
 	${1:<strong>Heads up!</strong> This alert needs your attention, but it's not super important.}
 </div>
 ]]></content>
-	<tabTrigger>alert:info</tabTrigger>
+	<tabTrigger>b4:alert:info</tabTrigger>
 </snippet>

--- a/snippets/components/alerts/info_link.sublime-snippet
+++ b/snippets/components/alerts/info_link.sublime-snippet
@@ -4,5 +4,5 @@
 	${1:<strong>Heads up!</strong> This <a href="#" class="alert-link">alert needs your attention</a>, but it's not super important.}
 </div>
 ]]></content>
-	<tabTrigger>alert:info:l</tabTrigger>
+	<tabTrigger>b4:alert:info:l</tabTrigger>
 </snippet>

--- a/snippets/components/alerts/success.sublime-snippet
+++ b/snippets/components/alerts/success.sublime-snippet
@@ -4,7 +4,7 @@
 	${1:<strong>Well done!</strong> You successfully read this important alert message.}
 </div>
 ]]></content>
-	<tabTrigger>alert:success</tabTrigger>
+	<tabTrigger>b4:alert:success</tabTrigger>
 </snippet>
 
 <!--

--- a/snippets/components/alerts/success_link.sublime-snippet
+++ b/snippets/components/alerts/success_link.sublime-snippet
@@ -4,5 +4,5 @@
 	${1:<strong>Well done!</strong> You successfully read <a href="#" class="alert-link">this important alert message</a>.}
 </div>
 ]]></content>
-	<tabTrigger>alert:success:l</tabTrigger>
+	<tabTrigger>b4:alert:success:l</tabTrigger>
 </snippet>

--- a/snippets/components/alerts/warning.sublime-snippet
+++ b/snippets/components/alerts/warning.sublime-snippet
@@ -4,5 +4,5 @@
     ${1:<strong>Warning!</strong> Better check yourself, you're not looking too good.}
 </div>
 ]]></content>
-	<tabTrigger>alert:warning</tabTrigger>
+	<tabTrigger>b4:alert:warning</tabTrigger>
 </snippet>

--- a/snippets/components/alerts/warning_link.sublime-snippet
+++ b/snippets/components/alerts/warning_link.sublime-snippet
@@ -4,5 +4,5 @@
 	${1:<strong>Warning!</strong> Better check yourself, you're <a href="#" class="alert-link">not looking too good</a>.}
 </div>
 ]]></content>
-	<tabTrigger>alert:warning:l</tabTrigger>
+	<tabTrigger>b4:alert:warning:l</tabTrigger>
 </snippet>

--- a/snippets/components/breadcrumb/breadcrumb.sublime-snippet
+++ b/snippets/components/breadcrumb/breadcrumb.sublime-snippet
@@ -13,5 +13,5 @@
 		<li class="active">${3:Data}</li>
 	</ol>
 ]]></content>
-	<tabTrigger>breadcrumb</tabTrigger>
+	<tabTrigger>b4:breadcrumb</tabTrigger>
 </snippet>

--- a/snippets/components/button_dropdown/button_dropdown.sublime-snippet
+++ b/snippets/components/button_dropdown/button_dropdown.sublime-snippet
@@ -13,5 +13,5 @@
 			</div>
 		</div>
 ]]></content>
-	<tabTrigger>button_dropdown</tabTrigger>
+	<tabTrigger>b4:button_dropdown</tabTrigger>
 </snippet>

--- a/snippets/components/button_dropdown/dropup.sublime-snippet
+++ b/snippets/components/button_dropdown/dropup.sublime-snippet
@@ -10,5 +10,5 @@
 	</div>
 </div>
 ]]></content>
-	<tabTrigger>button_dropdown:dropup</tabTrigger>
+	<tabTrigger>b4:button_dropdown:dropup</tabTrigger>
 </snippet>

--- a/snippets/components/button_dropdown/large.sublime-snippet
+++ b/snippets/components/button_dropdown/large.sublime-snippet
@@ -9,5 +9,5 @@
 	</div>
 </div>
 ]]></content>
-	<tabTrigger>button_dropdown:large</tabTrigger>
+	<tabTrigger>b4:button_dropdown:large</tabTrigger>
 </snippet>

--- a/snippets/components/button_dropdown/small.sublime-snippet
+++ b/snippets/components/button_dropdown/small.sublime-snippet
@@ -9,5 +9,5 @@
 	</div>
 </div>
 ]]></content>
-	<tabTrigger>button_dropdown:small</tabTrigger>
+	<tabTrigger>b4:button_dropdown:small</tabTrigger>
 </snippet>

--- a/snippets/components/button_dropdown/splited.sublime-snippet
+++ b/snippets/components/button_dropdown/splited.sublime-snippet
@@ -14,5 +14,5 @@
 	</div>
 </div>
 ]]></content>
-	<tabTrigger>button_dropdown:splited</tabTrigger>
+	<tabTrigger>b4:button_dropdown:splited</tabTrigger>
 </snippet>

--- a/snippets/components/button_group/button_group.sublime-snippet
+++ b/snippets/components/button_group/button_group.sublime-snippet
@@ -6,5 +6,5 @@
 	<button type="button" class="btn btn-secondary">${2:Right}</button>
 </div>
 ]]></content>
-	<tabTrigger>button_group</tabTrigger>
+	<tabTrigger>b4:button_group</tabTrigger>
 </snippet>

--- a/snippets/components/button_group/dropdown.sublime-snippet
+++ b/snippets/components/button_group/dropdown.sublime-snippet
@@ -15,5 +15,5 @@
 	</div>
 </div>
 ]]></content>
-	<tabTrigger>button_group:dropdown</tabTrigger>
+	<tabTrigger>b4:button_group:dropdown</tabTrigger>
 </snippet>

--- a/snippets/components/button_group/size.sublime-snippet
+++ b/snippets/components/button_group/size.sublime-snippet
@@ -4,5 +4,5 @@
 	$3
 </div>
 ]]></content>
-	<tabTrigger>button_group:size</tabTrigger>
+	<tabTrigger>b4:button_group:size</tabTrigger>
 </snippet>

--- a/snippets/components/button_group/toolbar.sublime-snippet
+++ b/snippets/components/button_group/toolbar.sublime-snippet
@@ -17,5 +17,5 @@
 	</div>
 </div>
 ]]></content>
-	<tabTrigger>button_group:toolbar</tabTrigger>
+	<tabTrigger>b4:button_group:toolbar</tabTrigger>
 </snippet>

--- a/snippets/components/buttons/a.sublime-snippet
+++ b/snippets/components/buttons/a.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[
 <a class="btn btn-primary" href="${1:#}" role="button">$2</a>
 ]]></content>
-	<tabTrigger>button:a</tabTrigger>
+	<tabTrigger>b4:button:a</tabTrigger>
 </snippet>

--- a/snippets/components/buttons/block.sublime-snippet
+++ b/snippets/components/buttons/block.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[
 <button type="button" class="btn btn-primary btn-lg btn-block">$1</button>
 ]]></content>
-	<tabTrigger>button:block</tabTrigger>
+	<tabTrigger>b4:button:block</tabTrigger>
 </snippet>

--- a/snippets/components/buttons/button.sublime-snippet
+++ b/snippets/components/buttons/button.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[
 <button type="button" class="btn btn-primary">$1</button>
 ]]></content>
-	<tabTrigger>button</tabTrigger>
+	<tabTrigger>b4:button</tabTrigger>
 </snippet>

--- a/snippets/components/buttons/checkbox.sublime-snippet
+++ b/snippets/components/buttons/checkbox.sublime-snippet
@@ -12,5 +12,5 @@
 	</label>
 </div>
 ]]></content>
-	<tabTrigger>button:checkbox</tabTrigger>
+	<tabTrigger>b4:button:checkbox</tabTrigger>
 </snippet>

--- a/snippets/components/buttons/colors.sublime-snippet
+++ b/snippets/components/buttons/colors.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[
 <button type="button" class="btn btn-${1:primary|primary|secondary|success|warning|danger|link}">$2</button>
 ]]></content>
-	<tabTrigger>button:colors</tabTrigger>
+	<tabTrigger>b4:button:colors</tabTrigger>
 </snippet>

--- a/snippets/components/buttons/input.sublime-snippet
+++ b/snippets/components/buttons/input.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[
 <input class="btn btn-primary" type="button" value="$2">
 ]]></content>
-	<tabTrigger>button:input</tabTrigger>
+	<tabTrigger>b4:button:input</tabTrigger>
 </snippet>

--- a/snippets/components/buttons/outline.sublime-snippet
+++ b/snippets/components/buttons/outline.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[
 <button type="button" class="btn btn-${1:primary|primary|secondary|success|warning|danger|link}-outline">$2</button>
 ]]></content>
-	<tabTrigger>button:outline</tabTrigger>
+	<tabTrigger>b4:button:outline</tabTrigger>
 </snippet>

--- a/snippets/components/buttons/radio.sublime-snippet
+++ b/snippets/components/buttons/radio.sublime-snippet
@@ -12,5 +12,5 @@
 	</label>
 </div>
 ]]></content>
-	<tabTrigger>button:radio</tabTrigger>
+	<tabTrigger>b4:button:radio</tabTrigger>
 </snippet>

--- a/snippets/components/buttons/sizes.sublime-snippet
+++ b/snippets/components/buttons/sizes.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[
 <button type="button" class="btn btn-primary btn-${1:lg|sm}">$2</button>
 ]]></content>
-	<tabTrigger>button:size</tabTrigger>
+	<tabTrigger>b4:button:size</tabTrigger>
 </snippet>

--- a/snippets/components/buttons/state.sublime-snippet
+++ b/snippets/components/buttons/state.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[
 <button type="button" class="btn btn-primary" disabled>$1</button>
 ]]></content>
-	<tabTrigger>button:state</tabTrigger>
+	<tabTrigger>b4:button:state</tabTrigger>
 </snippet>

--- a/snippets/components/buttons/state_a.sublime-snippet
+++ b/snippets/components/buttons/state_a.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[
 <a href="#" class="btn btn-primary ${1:active|disabled}" role="button">$2</a>
 ]]></content>
-	<tabTrigger>button:state:a</tabTrigger>
+	<tabTrigger>b4:button:state:a</tabTrigger>
 </snippet>

--- a/snippets/components/buttons/toggle.sublime-snippet
+++ b/snippets/components/buttons/toggle.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[
 <button type="button" class="btn btn-primary" data-toggle="button" aria-pressed="false" autocomplete="off">$1</button>
 ]]></content>
-	<tabTrigger>button:toggle</tabTrigger>
+	<tabTrigger>b4:button:toggle</tabTrigger>
 </snippet>

--- a/snippets/components/cards/bg-color.sublime-snippet
+++ b/snippets/components/cards/bg-color.sublime-snippet
@@ -9,5 +9,5 @@
 	</div>
 </div>
 ]]></content>
-	<tabTrigger>cards:background:color</tabTrigger>
+	<tabTrigger>b4:cards:background:color</tabTrigger>
 </snippet>

--- a/snippets/components/cards/cards.sublime-snippet
+++ b/snippets/components/cards/cards.sublime-snippet
@@ -9,5 +9,5 @@
 			</div>
 		</div>
 ]]></content>
-	<tabTrigger>cards</tabTrigger>
+	<tabTrigger>b4:cards</tabTrigger>
 </snippet>

--- a/snippets/components/cards/columns.sublime-snippet
+++ b/snippets/components/cards/columns.sublime-snippet
@@ -61,5 +61,5 @@
 	</div>
 </div>
 ]]></content>
-	<tabTrigger>cards:columns</tabTrigger>
+	<tabTrigger>b4:cards:columns</tabTrigger>
 </snippet>

--- a/snippets/components/cards/content-type.sublime-snippet
+++ b/snippets/components/cards/content-type.sublime-snippet
@@ -17,5 +17,5 @@
 	</div>
 </div>
 ]]></content>
-	<tabTrigger>cards:content_type</tabTrigger>
+	<tabTrigger>b4:cards:content_type</tabTrigger>
 </snippet>

--- a/snippets/components/cards/content-type_image.sublime-snippet
+++ b/snippets/components/cards/content-type_image.sublime-snippet
@@ -7,5 +7,5 @@
 	<a href="${3:#}" class="card-link">${2:Another link}</a>
 </div>
 ]]></content>
-	<tabTrigger>cards:content_type:img</tabTrigger>
+	<tabTrigger>b4:cards:content_type:img</tabTrigger>
 </snippet>

--- a/snippets/components/cards/content-type_list.sublime-snippet
+++ b/snippets/components/cards/content-type_list.sublime-snippet
@@ -7,5 +7,5 @@
 	</div>
 </div>
 ]]></content>
-	<tabTrigger>cards:content_type:list</tabTrigger>
+	<tabTrigger>b4:cards:content_type:list</tabTrigger>
 </snippet>

--- a/snippets/components/cards/content-type_title.sublime-snippet
+++ b/snippets/components/cards/content-type_title.sublime-snippet
@@ -13,5 +13,5 @@
 	</div>
 </div>
 ]]></content>
-	<tabTrigger>cards:content_type:title</tabTrigger>
+	<tabTrigger>b4:cards:content_type:title</tabTrigger>
 </snippet>

--- a/snippets/components/cards/decks.sublime-snippet
+++ b/snippets/components/cards/decks.sublime-snippet
@@ -29,5 +29,5 @@
 	</div>
 </div>
 ]]></content>
-	<tabTrigger>cards:decks</tabTrigger>
+	<tabTrigger>b4:cards:decks</tabTrigger>
 </snippet>

--- a/snippets/components/cards/groups.sublime-snippet
+++ b/snippets/components/cards/groups.sublime-snippet
@@ -27,5 +27,5 @@
 	</div>
 </div>
 ]]></content>
-	<tabTrigger>cards:groups</tabTrigger>
+	<tabTrigger>b4:cards:groups</tabTrigger>
 </snippet>

--- a/snippets/components/cards/header&footer-quote.sublime-snippet
+++ b/snippets/components/cards/header&footer-quote.sublime-snippet
@@ -12,5 +12,5 @@
 	</div>
 </div>
 ]]></content>
-	<tabTrigger>cards:header:quote</tabTrigger>
+	<tabTrigger>b4:cards:header:quote</tabTrigger>
 </snippet>

--- a/snippets/components/cards/header&footer.sublime-snippet
+++ b/snippets/components/cards/header&footer.sublime-snippet
@@ -11,5 +11,5 @@
 	</div>
 </div>
 ]]></content>
-	<tabTrigger>cards:header</tabTrigger>
+	<tabTrigger>b4:cards:header</tabTrigger>
 </snippet>

--- a/snippets/components/cards/image-caps.sublime-snippet
+++ b/snippets/components/cards/image-caps.sublime-snippet
@@ -17,5 +17,5 @@
 	<img class="card-img-bottom" data-src="${1:holder.js/100%x180/}" alt="${2:Card image cap}">
 </div>
 ]]></content>
-	<tabTrigger>cards:image:caps</tabTrigger>
+	<tabTrigger>b4:cards:image:caps</tabTrigger>
 </snippet>

--- a/snippets/components/cards/image-overlays.sublime-snippet
+++ b/snippets/components/cards/image-overlays.sublime-snippet
@@ -9,5 +9,5 @@
 	</div>
 </div>
 ]]></content>
-	<tabTrigger>cards:image:overlays</tabTrigger>
+	<tabTrigger>b4:cards:image:overlays</tabTrigger>
 </snippet>

--- a/snippets/components/cards/size.sublime-snippet
+++ b/snippets/components/cards/size.sublime-snippet
@@ -17,5 +17,5 @@
 	</div>
 </div>
 ]]></content>
-	<tabTrigger>cards:size</tabTrigger>
+	<tabTrigger>b4:cards:size</tabTrigger>
 </snippet>

--- a/snippets/components/cards/size_custom.sublime-snippet
+++ b/snippets/components/cards/size_custom.sublime-snippet
@@ -6,5 +6,5 @@
 	<a href="${3:#}" class="btn btn-primary">${4:Go somewhere}</a>
 </div>
 ]]></content>
-	<tabTrigger>cards:size:custom</tabTrigger>
+	<tabTrigger>b4:cards:size:custom</tabTrigger>
 </snippet>

--- a/snippets/components/cards/text-invert.sublime-snippet
+++ b/snippets/components/cards/text-invert.sublime-snippet
@@ -8,5 +8,5 @@
 	</div>
 </div>
 ]]></content>
-	<tabTrigger>cards:text:invert</tabTrigger>
+	<tabTrigger>b4:cards:text:invert</tabTrigger>
 </snippet>

--- a/snippets/components/cards/text_align.sublime-snippet
+++ b/snippets/components/cards/text_align.sublime-snippet
@@ -6,5 +6,5 @@
 			<a href="${4:#}" class="btn btn-primary">${5:Go somewhere}</a>
 		</div>
 ]]></content>
-	<tabTrigger>cards:align</tabTrigger>
+	<tabTrigger>b4:cards:align</tabTrigger>
 </snippet>

--- a/snippets/components/carousel/caption.sublime-snippet
+++ b/snippets/components/carousel/caption.sublime-snippet
@@ -8,5 +8,5 @@
 		</div>
 	</div>
 ]]></content>
-	<tabTrigger>carousel:caption</tabTrigger>
+	<tabTrigger>b4:carousel:caption</tabTrigger>
 </snippet>

--- a/snippets/components/carousel/carousel.sublime-snippet
+++ b/snippets/components/carousel/carousel.sublime-snippet
@@ -27,5 +27,5 @@
 			</a>
 		</div>
 ]]></content>
-	<tabTrigger>carousel</tabTrigger>
+	<tabTrigger>b4:carousel</tabTrigger>
 </snippet>

--- a/snippets/components/collapse/accordion.sublime-snippet
+++ b/snippets/components/collapse/accordion.sublime-snippet
@@ -39,5 +39,5 @@
 		</div>
 	</div>
 ]]></content>
-	<tabTrigger>collapse:accordion</tabTrigger>
+	<tabTrigger>b4:collapse:accordion</tabTrigger>
 </snippet>

--- a/snippets/components/collapse/collapse.sublime-snippet
+++ b/snippets/components/collapse/collapse.sublime-snippet
@@ -14,5 +14,5 @@
 			</div>
 		</div>
 ]]></content>
-	<tabTrigger>collapse</tabTrigger>
+	<tabTrigger>b4:collapse</tabTrigger>
 </snippet>

--- a/snippets/components/dropdown/alignement.sublime-snippet
+++ b/snippets/components/dropdown/alignement.sublime-snippet
@@ -4,5 +4,5 @@
 	${1:...}
 </div>
 ]]></content>
-	<tabTrigger>dropdown:align</tabTrigger>
+	<tabTrigger>b4:dropdown:align</tabTrigger>
 </snippet>

--- a/snippets/components/dropdown/button.sublime-snippet
+++ b/snippets/components/dropdown/button.sublime-snippet
@@ -11,5 +11,5 @@
 	</div>
 </div>
 ]]></content>
-	<tabTrigger>dropdown:button</tabTrigger>
+	<tabTrigger>b4:dropdown:button</tabTrigger>
 </snippet>

--- a/snippets/components/dropdown/dropdown.sublime-snippet
+++ b/snippets/components/dropdown/dropdown.sublime-snippet
@@ -11,5 +11,5 @@
 			</div>
 		</div>
 ]]></content>
-	<tabTrigger>dropdown</tabTrigger>
+	<tabTrigger>b4:dropdown</tabTrigger>
 </snippet>

--- a/snippets/components/dropdown/menu-disabled.sublime-snippet
+++ b/snippets/components/dropdown/menu-disabled.sublime-snippet
@@ -6,5 +6,5 @@
 	<a class="dropdown-item" href="${1:#}">${2:Another link}</a>
 </div>
 ]]></content>
-	<tabTrigger>dropdown:menu:disabled</tabTrigger>
+	<tabTrigger>b4:dropdown:menu:disabled</tabTrigger>
 </snippet>

--- a/snippets/components/dropdown/menu-divide.sublime-snippet
+++ b/snippets/components/dropdown/menu-divide.sublime-snippet
@@ -8,5 +8,5 @@
 	<a class="dropdown-item" href="${1:#}">${2:Separated link}</a>
 </div>
 ]]></content>
-	<tabTrigger>dropdown:menu:divider</tabTrigger>
+	<tabTrigger>b4:dropdown:menu:divider</tabTrigger>
 </snippet>

--- a/snippets/components/dropdown/menu-header.sublime-snippet
+++ b/snippets/components/dropdown/menu-header.sublime-snippet
@@ -6,5 +6,5 @@
 	<a class="dropdown-item" href="${1:#}">${2:Another action}</a>
 </div>
 ]]></content>
-	<tabTrigger>dropdown:menu:header</tabTrigger>
+	<tabTrigger>b4:dropdown:menu:header</tabTrigger>
 </snippet>

--- a/snippets/components/forms/checkbox-custom.sublime-snippet
+++ b/snippets/components/forms/checkbox-custom.sublime-snippet
@@ -6,5 +6,5 @@
 	Check this custom checkbox
 </label>
 ]]></content>
-	<tabTrigger>form:checkbox:custom</tabTrigger>
+	<tabTrigger>b4:form:checkbox:custom</tabTrigger>
 </snippet>

--- a/snippets/components/forms/checkbox-inline.sublime-snippet
+++ b/snippets/components/forms/checkbox-inline.sublime-snippet
@@ -10,5 +10,5 @@
 	<input type="checkbox" id="${1:inlineCheckbox3}" value="${2:option3}"> ${3:3}
 </label>
 ]]></content>
-	<tabTrigger>form:checkbox:inline</tabTrigger>
+	<tabTrigger>b4:form:checkbox:inline</tabTrigger>
 </snippet>

--- a/snippets/components/forms/checkbox-no_label.sublime-snippet
+++ b/snippets/components/forms/checkbox-no_label.sublime-snippet
@@ -6,5 +6,5 @@
 	</label>
 </div>
 ]]></content>
-	<tabTrigger>form:checkbox:wo_label</tabTrigger>
+	<tabTrigger>b4:form:checkbox:wo_label</tabTrigger>
 </snippet>

--- a/snippets/components/forms/checkbox.sublime-snippet
+++ b/snippets/components/forms/checkbox.sublime-snippet
@@ -53,5 +53,5 @@
 	</div>
 </form>
 ]]></content>
-	<tabTrigger>form:checkbox</tabTrigger>
+	<tabTrigger>b4:form:checkbox</tabTrigger>
 </snippet>

--- a/snippets/components/forms/column-sizing.sublime-snippet
+++ b/snippets/components/forms/column-sizing.sublime-snippet
@@ -12,5 +12,5 @@
 	</div>
 </div>
 ]]></content>
-	<tabTrigger>form:column:sizing</tabTrigger>
+	<tabTrigger>b4:form:column:sizing</tabTrigger>
 </snippet>

--- a/snippets/components/forms/disabled.sublime-snippet
+++ b/snippets/components/forms/disabled.sublime-snippet
@@ -21,5 +21,5 @@
 	</fieldset>
 </form>
 ]]></content>
-	<tabTrigger>form:disabled</tabTrigger>
+	<tabTrigger>b4:form:disabled</tabTrigger>
 </snippet>

--- a/snippets/components/forms/file-browser.sublime-snippet
+++ b/snippets/components/forms/file-browser.sublime-snippet
@@ -5,5 +5,5 @@
 	<span class="file-custom"></span>
 </label>
 ]]></content>
-	<tabTrigger>form:file-browser</tabTrigger>
+	<tabTrigger>b4:form:file-browser</tabTrigger>
 </snippet>

--- a/snippets/components/forms/form_controls.sublime-snippet
+++ b/snippets/components/forms/form_controls.sublime-snippet
@@ -65,5 +65,5 @@
 	<button type="submit" class="btn btn-primary">Submit</button>
 </form>
 ]]></content>
-	<tabTrigger>form_controls</tabTrigger>
+	<tabTrigger>b4:form_controls</tabTrigger>
 </snippet>

--- a/snippets/components/forms/grid.sublime-snippet
+++ b/snippets/components/forms/grid.sublime-snippet
@@ -53,5 +53,5 @@
 	</div>
 </form>
 ]]></content>
-	<tabTrigger>form:grid</tabTrigger>
+	<tabTrigger>b4:form:grid</tabTrigger>
 </snippet>

--- a/snippets/components/forms/group.sublime-snippet
+++ b/snippets/components/forms/group.sublime-snippet
@@ -11,5 +11,5 @@
 	</fieldset>
 </form>
 ]]></content>
-	<tabTrigger>form:group</tabTrigger>
+	<tabTrigger>b4:form:group</tabTrigger>
 </snippet>

--- a/snippets/components/forms/help-text.sublime-snippet
+++ b/snippets/components/forms/help-text.sublime-snippet
@@ -4,5 +4,5 @@
 	Some inline text with a small tag looks like this.
 </small>
 ]]></content>
-	<tabTrigger>form:text:help</tabTrigger>
+	<tabTrigger>b4:form:text:help</tabTrigger>
 </snippet>

--- a/snippets/components/forms/hidden.sublime-snippet
+++ b/snippets/components/forms/hidden.sublime-snippet
@@ -5,5 +5,5 @@
 	<input type="email" class="form-control" id="${1:exampleInputEmail3}" placeholder="${10:Enter email}">
 </div>
 ]]></content>
-	<tabTrigger>form:hidden</tabTrigger>
+	<tabTrigger>b4:form:hidden</tabTrigger>
 </snippet>

--- a/snippets/components/forms/inline.sublime-snippet
+++ b/snippets/components/forms/inline.sublime-snippet
@@ -12,5 +12,5 @@
 	<button type="submit" class="btn btn-primary">Send invitation</button>
 </form>
 ]]></content>
-	<tabTrigger>form:inline</tabTrigger>
+	<tabTrigger>b4:form:inline</tabTrigger>
 </snippet>

--- a/snippets/components/forms/input-sizing.sublime-snippet
+++ b/snippets/components/forms/input-sizing.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[
 <input class="form-control {2:form-control-{1:sm|lg}}" type="text" placeholder="${3:.input...}">
 ]]></content>
-	<tabTrigger>form:input:sizing</tabTrigger>
+	<tabTrigger>b4:form:input:sizing</tabTrigger>
 </snippet>

--- a/snippets/components/forms/radio-custom.sublime-snippet
+++ b/snippets/components/forms/radio-custom.sublime-snippet
@@ -11,5 +11,5 @@
 	Or toggle this other custom radio
 </label>
 ]]></content>
-	<tabTrigger>form:radio:custom</tabTrigger>
+	<tabTrigger>b4:form:radio:custom</tabTrigger>
 </snippet>

--- a/snippets/components/forms/radio-inline.sublime-snippet
+++ b/snippets/components/forms/radio-inline.sublime-snippet
@@ -10,5 +10,5 @@
 	<input type="radio" name="${1:inlineRadioOptions}" id="${2:inlineRadio3}" value="${3:option3}"> ${3:3}
 </label>
 ]]></content>
-	<tabTrigger>form:radio:inline</tabTrigger>
+	<tabTrigger>b4:form:radio:inline</tabTrigger>
 </snippet>

--- a/snippets/components/forms/radio-stacked-custom.sublime-snippet
+++ b/snippets/components/forms/radio-stacked-custom.sublime-snippet
@@ -13,5 +13,5 @@
 	</label>
 </div>
 ]]></content>
-	<tabTrigger>form:radio:stacked:custom</tabTrigger>
+	<tabTrigger>b4:form:radio:stacked:custom</tabTrigger>
 </snippet>

--- a/snippets/components/forms/radio-wo_label.sublime-snippet
+++ b/snippets/components/forms/radio-wo_label.sublime-snippet
@@ -6,5 +6,5 @@
 	</label>
 </div>
 ]]></content>
-	<tabTrigger>form:radio:wo_label</tabTrigger>
+	<tabTrigger>b4:form:radio:wo_label</tabTrigger>
 </snippet>

--- a/snippets/components/forms/radio.sublime-snippet
+++ b/snippets/components/forms/radio.sublime-snippet
@@ -19,5 +19,5 @@
 	</label>
 </div>
 ]]></content>
-	<tabTrigger>form:radio</tabTrigger>
+	<tabTrigger>b4:form:radio</tabTrigger>
 </snippet>

--- a/snippets/components/forms/readonly.sublime-snippet
+++ b/snippets/components/forms/readonly.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[
 <input class="form-control" type="text" placeholder="${10:Readonly input here…" readonl}y>
 ]]></content>
-	<tabTrigger>form:readonly</tabTrigger>
+	<tabTrigger>b4:form:readonly</tabTrigger>
 </snippet>

--- a/snippets/components/forms/select-menu-custom.sublime-snippet
+++ b/snippets/components/forms/select-menu-custom.sublime-snippet
@@ -7,5 +7,5 @@
 	<option value="3">Three</option>
 </select>
 ]]></content>
-	<tabTrigger>form:select-menu:custom</tabTrigger>
+	<tabTrigger>b4:form:select-menu:custom</tabTrigger>
 </snippet>

--- a/snippets/components/forms/select-sizing.sublime-snippet
+++ b/snippets/components/forms/select-sizing.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[
 <select class="form-control {2:form-control-{1:sm|lg}}">${3}</select>
 ]]></content>
-	<tabTrigger>form:input:sizing</tabTrigger>
+	<tabTrigger>b4:form:input:sizing</tabTrigger>
 </snippet>

--- a/snippets/components/forms/static-control-inline.sublime-snippet
+++ b/snippets/components/forms/static-control-inline.sublime-snippet
@@ -12,5 +12,5 @@
 	<button type="submit" class="btn btn-primary">Confirm identity</button>
 </form>
 ]]></content>
-	<tabTrigger>form:static_control:inline</tabTrigger>
+	<tabTrigger>b4:form:static_control:inline</tabTrigger>
 </snippet>

--- a/snippets/components/forms/static-control.sublime-snippet
+++ b/snippets/components/forms/static-control.sublime-snippet
@@ -15,5 +15,5 @@
 	</div>
 </form>
 ]]></content>
-	<tabTrigger>form:static_control</tabTrigger>
+	<tabTrigger>b4:form:static_control</tabTrigger>
 </snippet>

--- a/snippets/components/forms/validation.sublime-snippet
+++ b/snippets/components/forms/validation.sublime-snippet
@@ -38,5 +38,5 @@
 	</div>
 </div>
 ]]></content>
-	<tabTrigger>form:validation</tabTrigger>
+	<tabTrigger>b4:form:validation</tabTrigger>
 </snippet>

--- a/snippets/components/input_groups/addon.sublime-snippet
+++ b/snippets/components/input_groups/addon.sublime-snippet
@@ -19,5 +19,5 @@
 			</div>
 		</div>
 ]]></content>
-	<tabTrigger>input_group:addon</tabTrigger>
+	<tabTrigger>b4:input_group:addon</tabTrigger>
 </snippet>

--- a/snippets/components/input_groups/checkbox_addon.sublime-snippet
+++ b/snippets/components/input_groups/checkbox_addon.sublime-snippet
@@ -19,5 +19,5 @@
 	</div>
 </div>
 ]]></content>
-	<tabTrigger>input_group:addon:checkbox_radio</tabTrigger>
+	<tabTrigger>b4:input_group:addon:checkbox_radio</tabTrigger>
 </snippet>

--- a/snippets/components/input_groups/dropdown.sublime-snippet
+++ b/snippets/components/input_groups/dropdown.sublime-snippet
@@ -37,5 +37,5 @@
 			</div>
 		</div>
 ]]></content>
-	<tabTrigger>input_group:dropdown</tabTrigger>
+	<tabTrigger>b4:input_group:dropdown</tabTrigger>
 </snippet>

--- a/snippets/components/input_groups/input_group.sublime-snippet
+++ b/snippets/components/input_groups/input_group.sublime-snippet
@@ -22,5 +22,5 @@
 			<span class="input-group-addon">.00</span>
 		</div>
 ]]></content>
-	<tabTrigger>input_group</tabTrigger>
+	<tabTrigger>b4:input_group</tabTrigger>
 </snippet>

--- a/snippets/components/input_groups/seg_button.sublime-snippet
+++ b/snippets/components/input_groups/seg_button.sublime-snippet
@@ -37,5 +37,5 @@
 			</div>
 		</div>
 ]]></content>
-	<tabTrigger>input_group:segmented_button</tabTrigger>
+	<tabTrigger>b4:input_group:segmented_button</tabTrigger>
 </snippet>

--- a/snippets/components/input_groups/sizing.sublime-snippet
+++ b/snippets/components/input_groups/sizing.sublime-snippet
@@ -15,5 +15,5 @@
 			<input type="text" class="form-control" placeholder="${1:Username}" aria-describedby="sizing-addon3">
 		</div>
 ]]></content>
-	<tabTrigger>input_group:sizing</tabTrigger>
+	<tabTrigger>b4:input_group:sizing</tabTrigger>
 </snippet>

--- a/snippets/components/jumbotron/fluid_jumbotron.sublime-snippet
+++ b/snippets/components/jumbotron/fluid_jumbotron.sublime-snippet
@@ -7,5 +7,5 @@
 			</div>
 		</div>
 ]]></content>
-	<tabTrigger>jumbotron:fluid</tabTrigger>
+	<tabTrigger>b4:jumbotron:fluid</tabTrigger>
 </snippet>

--- a/snippets/components/jumbotron/jumbotron.sublime-snippet
+++ b/snippets/components/jumbotron/jumbotron.sublime-snippet
@@ -10,7 +10,7 @@
 			</p>
 		</div>
 ]]></content>
-	<tabTrigger>jumbotron</tabTrigger>
+	<tabTrigger>b4:jumbotron</tabTrigger>
 </snippet>
 
 

--- a/snippets/components/labels/context.sublime-snippet
+++ b/snippets/components/labels/context.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[
         <span class="label label-${1:default|primary|success|info|warning|danger}">$2</span>
 ]]></content>
-	<tabTrigger>label:context</tabTrigger>
+	<tabTrigger>b4:label:context</tabTrigger>
 </snippet>

--- a/snippets/components/labels/heading.sublime-snippet
+++ b/snippets/components/labels/heading.sublime-snippet
@@ -7,5 +7,5 @@
 		<h5>${2:Example heading <span class="label label-default">${1:New}</span>}</h5>
 		<h6>${2:Example heading <span class="label label-default">${1:New}</span>}</h6>
 ]]></content>
-	<tabTrigger>label:heading</tabTrigger>
+	<tabTrigger>b4:label:heading</tabTrigger>
 </snippet>

--- a/snippets/components/labels/label.sublime-snippet
+++ b/snippets/components/labels/label.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[
 <span class="label label-default">$1</span>
 ]]></content>
-	<tabTrigger>label</tabTrigger>
+	<tabTrigger>b4:label</tabTrigger>
 </snippet>

--- a/snippets/components/labels/pill.sublime-snippet
+++ b/snippets/components/labels/pill.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[
         <span class="label label-pill label-${1:default|primary|success|info|warning|danger}">$2</span>
 ]]></content>
-	<tabTrigger>label:context</tabTrigger>
+	<tabTrigger>b4:label:context</tabTrigger>
 </snippet>

--- a/snippets/components/lists/button.sublime-snippet
+++ b/snippets/components/lists/button.sublime-snippet
@@ -6,5 +6,5 @@
 			<button type="button" class="list-group-item">${1:Morbi leo risus}</button>
 		</div>
 ]]></content>
-	<tabTrigger>list:button</tabTrigger>
+	<tabTrigger>b4:list:button</tabTrigger>
 </snippet>

--- a/snippets/components/lists/context-a.sublime-snippet
+++ b/snippets/components/lists/context-a.sublime-snippet
@@ -4,5 +4,5 @@
 			<a href="#" class="list-group-item list-group-item-${1:success|info|warning|danger}">${2:Dapibus ac facilisis in}</a>
 		</div>
 ]]></content>
-	<tabTrigger>list:context:a</tabTrigger>
+	<tabTrigger>b4:list:context:a</tabTrigger>
 </snippet>

--- a/snippets/components/lists/context.sublime-snippet
+++ b/snippets/components/lists/context.sublime-snippet
@@ -4,5 +4,5 @@
 			<li class="list-group-item list-group-item-${1:success|info|warning|danger}">${2:Dapibus ac facilisis in}</li>
 		</ul>
 ]]></content>
-	<tabTrigger>list:context</tabTrigger>
+	<tabTrigger>b4:list:context</tabTrigger>
 </snippet>

--- a/snippets/components/lists/custom_content.sublime-snippet
+++ b/snippets/components/lists/custom_content.sublime-snippet
@@ -15,5 +15,5 @@
 			</a>
 		</div>
 ]]></content>
-	<tabTrigger>list:custom</tabTrigger>
+	<tabTrigger>b4:list:custom</tabTrigger>
 </snippet>

--- a/snippets/components/lists/label.sublime-snippet
+++ b/snippets/components/lists/label.sublime-snippet
@@ -15,5 +15,5 @@
 			</li>
 		</ul>
 ]]></content>
-	<tabTrigger>list:label</tabTrigger>
+	<tabTrigger>b4:list:label</tabTrigger>
 </snippet>

--- a/snippets/components/lists/linked.sublime-snippet
+++ b/snippets/components/lists/linked.sublime-snippet
@@ -6,5 +6,5 @@
 			<a href="#" class="list-group-item">${1:Morbi leo risus}</a>
 		</div>
 ]]></content>
-	<tabTrigger>list:label</tabTrigger>
+	<tabTrigger>b4:list:label</tabTrigger>
 </snippet>

--- a/snippets/components/lists/list-disabled.sublime-snippet
+++ b/snippets/components/lists/list-disabled.sublime-snippet
@@ -6,5 +6,5 @@
 			<a href="#" class="list-group-item">${1:Morbi leo risus}</a>
 		</div>
 ]]></content>
-	<tabTrigger>list:disabled</tabTrigger>
+	<tabTrigger>b4:list:disabled</tabTrigger>
 </snippet>

--- a/snippets/components/lists/list.sublime-snippet
+++ b/snippets/components/lists/list.sublime-snippet
@@ -6,5 +6,5 @@
 			<li class="list-group-item">${1:Morbi leo risus}</li>
 		</ul>
 ]]></content>
-	<tabTrigger>list</tabTrigger>
+	<tabTrigger>b4:list</tabTrigger>
 </snippet>

--- a/snippets/components/modals/button.sublime-snippet
+++ b/snippets/components/modals/button.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[
         <button class="btn btn-primary" data-toggle="modal" data-target="#${1:bd-example-modal}">${2:Large modal}</button>
 ]]></content>
-	<tabTrigger>modal:button</tabTrigger>
+	<tabTrigger>b4:modal:button</tabTrigger>
 </snippet>

--- a/snippets/components/modals/content.sublime-snippet
+++ b/snippets/components/modals/content.sublime-snippet
@@ -35,5 +35,5 @@
 			</div>
 		</div>
 ]]></content>
-	<tabTrigger>modal:cotent</tabTrigger>
+	<tabTrigger>b4:modal:cotent</tabTrigger>
 </snippet>

--- a/snippets/components/modals/grid.sublime-snippet
+++ b/snippets/components/modals/grid.sublime-snippet
@@ -46,5 +46,5 @@
 			</button>
 		</div>
 ]]></content>
-	<tabTrigger>modal:grid</tabTrigger>
+	<tabTrigger>b4:modal:grid</tabTrigger>
 </snippet>

--- a/snippets/components/modals/modal.sublime-snippet
+++ b/snippets/components/modals/modal.sublime-snippet
@@ -21,5 +21,5 @@
 			</div><!-- /.modal-dialog -->
 		</div><!-- /.modal -->
 ]]></content>
-	<tabTrigger>modal</tabTrigger>
+	<tabTrigger>b4:modal</tabTrigger>
 </snippet>

--- a/snippets/components/modals/sizes.sublime-snippet
+++ b/snippets/components/modals/sizes.sublime-snippet
@@ -8,5 +8,5 @@
 			</div>
 		</div>
 ]]></content>
-	<tabTrigger>modal:sizes</tabTrigger>
+	<tabTrigger>b4:modal:sizes</tabTrigger>
 </snippet>

--- a/snippets/components/navbar/collapse.sublime-snippet
+++ b/snippets/components/navbar/collapse.sublime-snippet
@@ -12,5 +12,5 @@
           </button>
         </nav>
 ]]></content>
-		<tabTrigger>navbar:collapse</tabTrigger>
+		<tabTrigger>b4:navbar:collapse</tabTrigger>
 </snippet>

--- a/snippets/components/navbar/color.sublime-snippet
+++ b/snippets/components/navbar/color.sublime-snippet
@@ -4,5 +4,5 @@
           ${4:...}
         </nav>
 ]]></content>
-		<tabTrigger>navbar:color</tabTrigger>
+		<tabTrigger>b4:navbar:color</tabTrigger>
 </snippet>

--- a/snippets/components/navbar/container-in.sublime-snippet
+++ b/snippets/components/navbar/container-in.sublime-snippet
@@ -6,5 +6,5 @@
           </div>
         </nav>
 ]]></content>
-		<tabTrigger>navbar:container:in</tabTrigger>
+		<tabTrigger>b4:navbar:container:in</tabTrigger>
 </snippet>

--- a/snippets/components/navbar/container-out.sublime-snippet
+++ b/snippets/components/navbar/container-out.sublime-snippet
@@ -6,5 +6,5 @@
           </nav>
         </div>
 ]]></content>
-		<tabTrigger>navbar:container:out</tabTrigger>
+		<tabTrigger>b4:navbar:container:out</tabTrigger>
 </snippet>

--- a/snippets/components/navbar/fixed-bottom.sublime-snippet
+++ b/snippets/components/navbar/fixed-bottom.sublime-snippet
@@ -4,5 +4,5 @@
           <a class="navbar-brand" href="${1:#}">${2:Fixed bottom}</a>
         </nav>
 ]]></content>
-		<tabTrigger>navbar:fixed:bottom</tabTrigger>
+		<tabTrigger>b4:navbar:fixed:bottom</tabTrigger>
 </snippet>

--- a/snippets/components/navbar/fixed-top.sublime-snippet
+++ b/snippets/components/navbar/fixed-top.sublime-snippet
@@ -4,5 +4,5 @@
           <a class="navbar-brand" href="${1:#}">${2:Fixed top}</a>
         </nav>
 ]]></content>
-		<tabTrigger>navbar:fixed:top</tabTrigger>
+		<tabTrigger>b4:navbar:fixed:top</tabTrigger>
 </snippet>

--- a/snippets/components/navbar/navbar.sublime-snippet
+++ b/snippets/components/navbar/navbar.sublime-snippet
@@ -22,5 +22,5 @@
 			</form>
 		</nav>
 ]]></content>
-		<tabTrigger>navbar</tabTrigger>
+		<tabTrigger>b4:navbar</tabTrigger>
 </snippet>

--- a/snippets/components/navbar/toggler.sublime-snippet
+++ b/snippets/components/navbar/toggler.sublime-snippet
@@ -23,5 +23,5 @@
           </div>
         </nav>
 ]]></content>
-		<tabTrigger>navbar:toggler</tabTrigger>
+		<tabTrigger>b4:navbar:toggler</tabTrigger>
 </snippet>

--- a/snippets/components/navs/dropdown.sublime-snippet
+++ b/snippets/components/navs/dropdown.sublime-snippet
@@ -22,5 +22,5 @@
 			</li>
 		</ul>
 ]]></content>
-    <tabTrigger>nav:dropdown</tabTrigger>
+    <tabTrigger>b4:nav:dropdown</tabTrigger>
 </snippet>

--- a/snippets/components/navs/inline.sublime-snippet
+++ b/snippets/components/navs/inline.sublime-snippet
@@ -7,5 +7,5 @@
 			<a class="nav-link disabled" href="${1:#}">${3:Disabled}</a>
 		</nav>
 ]]></content>
-	<tabTrigger>nav:inline</tabTrigger>
+	<tabTrigger>b4:nav:inline</tabTrigger>
 </snippet>

--- a/snippets/components/navs/nav.sublime-snippet
+++ b/snippets/components/navs/nav.sublime-snippet
@@ -15,5 +15,5 @@
 			</li>
 		</ul>
 ]]></content>
-	<tabTrigger>nav</tabTrigger>
+	<tabTrigger>b4:nav</tabTrigger>
 </snippet>

--- a/snippets/components/navs/pills-dropdown.sublime-snippet
+++ b/snippets/components/navs/pills-dropdown.sublime-snippet
@@ -22,5 +22,5 @@
 			</li>
 		</ul>
 ]]></content>
-    <tabTrigger>nav:pills:dropdown</tabTrigger>
+    <tabTrigger>b4:nav:pills:dropdown</tabTrigger>
 </snippet>

--- a/snippets/components/navs/pills-stacked.sublime-snippet
+++ b/snippets/components/navs/pills-stacked.sublime-snippet
@@ -15,5 +15,5 @@
 			</li>
 		</ul>
 ]]></content>
-    <tabTrigger>nav:pills:stacked</tabTrigger>
+    <tabTrigger>b4:nav:pills:stacked</tabTrigger>
 </snippet>

--- a/snippets/components/navs/pills.sublime-snippet
+++ b/snippets/components/navs/pills.sublime-snippet
@@ -15,5 +15,5 @@
 			</li>
 		</ul>
 ]]></content>
-    <tabTrigger>nav:pills</tabTrigger>
+    <tabTrigger>b4:nav:pills</tabTrigger>
 </snippet>

--- a/snippets/components/navs/tabs.sublime-snippet
+++ b/snippets/components/navs/tabs.sublime-snippet
@@ -15,5 +15,5 @@
 			</li>
 		</ul>
 ]]></content>
-    <tabTrigger>nav:tabs</tabTrigger>
+    <tabTrigger>b4:nav:tabs</tabTrigger>
 </snippet>

--- a/snippets/components/pagination/pagination.sublime-snippet
+++ b/snippets/components/pagination/pagination.sublime-snippet
@@ -22,7 +22,7 @@
 			</ul>
 		</nav>
 ]]></content>
-	<tabTrigger>pagination</tabTrigger>
+	<tabTrigger>b4:pagination</tabTrigger>
 </snippet>
 
 

--- a/snippets/components/popovers/popover.sublime-snippet
+++ b/snippets/components/popovers/popover.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[
 		<button type="button" class="btn btn-lg btn-danger bd-popover" data-toggle="popover" title="${2:Popover title}" data-content="${3:And here's some amazing content. It's very engaging. Right?}">${1:Click to toggle popover}</button>
 ]]></content>
-	<tabTrigger>...</tabTrigger>
+	<tabTrigger>b4:...</tabTrigger>
 </snippet>
 
 

--- a/snippets/components/progress/progress.sublime-snippet
+++ b/snippets/components/progress/progress.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[
 		<progress class="progress" value="${1:10}" max="100">$2</progress>
 ]]></content>
-	<tabTrigger>progress</tabTrigger>
+	<tabTrigger>b4:progress</tabTrigger>
 </snippet>
 
 

--- a/snippets/components/scrollspy/scrollspy.sublime-snippet
+++ b/snippets/components/scrollspy/scrollspy.sublime-snippet
@@ -3,5 +3,5 @@
 <!DOCTYPE html>
 	...
 ]]></content>
-	<tabTrigger>...</tabTrigger>
+	<tabTrigger>b4:...</tabTrigger>
 </snippet>

--- a/snippets/components/tooltip/.snippet.sublime-snippet
+++ b/snippets/components/tooltip/.snippet.sublime-snippet
@@ -4,5 +4,5 @@
 			${2:Tooltip on ${1:top|right|bottom|left}}
 		</button>
 ]]></content>
-	<tabTrigger>tooltip</tabTrigger>
+	<tabTrigger>b4:tooltip</tabTrigger>
 </snippet>

--- a/snippets/content/figures/figures.sublime-snippet
+++ b/snippets/content/figures/figures.sublime-snippet
@@ -5,5 +5,5 @@
 	<figcaption class="figure-caption">$3</figcaption>
 </figure>
 ]]></content>
-	<tabTrigger>content:figure</tabTrigger>
+	<tabTrigger>b4:content:figure</tabTrigger>
 </snippet>

--- a/snippets/content/images/responsive.sublime-snippet
+++ b/snippets/content/images/responsive.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[
 <img src="$1" class="img-responsive" alt="$2">
 ]]></content>
-	<tabTrigger>image:responsive</tabTrigger>
+	<tabTrigger>b4:image:responsive</tabTrigger>
 </snippet>

--- a/snippets/content/tables/table.sublime-snippet
+++ b/snippets/content/tables/table.sublime-snippet
@@ -13,5 +13,5 @@
 	</tbody>
 </table>
 ]]></content>
-	<tabTrigger>tables:table</tabTrigger>
+	<tabTrigger>b4:tables:table</tabTrigger>
 </snippet>

--- a/snippets/content/typography/blockquote.sublime-snippet
+++ b/snippets/content/typography/blockquote.sublime-snippet
@@ -5,5 +5,5 @@
 	<footer>${2:Someone famous in} <cite title="${3:Source Title}">${3:Source Title}</cite></footer>
 </blockquote>
 ]]></content>
-	<tabTrigger>typography:blockquotes</tabTrigger>
+	<tabTrigger>b4:typography:blockquotes</tabTrigger>
 </snippet>

--- a/snippets/content/typography/blockquote_reserve.sublime-snippet
+++ b/snippets/content/typography/blockquote_reserve.sublime-snippet
@@ -5,5 +5,5 @@
 	<footer>${2:Someone famous in} <cite title="${3:Source Title}">${3:Source Title}</cite></footer>
 </blockquote>
 ]]></content>
-	<tabTrigger>typography:blockquotes_reverse</tabTrigger>
+	<tabTrigger>b4:typography:blockquotes_reverse</tabTrigger>
 </snippet>

--- a/snippets/content/typography/description_lists.sublime-snippet
+++ b/snippets/content/typography/description_lists.sublime-snippet
@@ -16,7 +16,7 @@
 	<dd class="col-sm-9">${9:Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.}</dd>
 </dl>
 ]]></content>
-	<tabTrigger>typography:disabled_list</tabTrigger>
+	<tabTrigger>b4:typography:disabled_list</tabTrigger>
 </snippet>
 
 <!--

--- a/snippets/content/typography/display_heading.sublime-snippet
+++ b/snippets/content/typography/display_heading.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[
 <h1 class="display-${1:1|2|3|4}">$2</h1>
 ]]></content>
-	<tabTrigger>typography:display_heading</tabTrigger>
+	<tabTrigger>b4:typography:display_heading</tabTrigger>
 </snippet>

--- a/snippets/content/typography/lead.sublime-snippet
+++ b/snippets/content/typography/lead.sublime-snippet
@@ -4,5 +4,5 @@
     ${1:Lorem ipsum dolor sit amet, consectetur adipisicing elit. Integer posuere erat a ante.}
 </p>'
 ]]></content>
-	<tabTrigger>typography:lead</tabTrigger>
+	<tabTrigger>b4:typography:lead</tabTrigger>
 </snippet>

--- a/snippets/content/typography/list_inline.sublime-snippet
+++ b/snippets/content/typography/list_inline.sublime-snippet
@@ -6,5 +6,5 @@
 	<li>$3</li>
 </ul>
 ]]></content>
-	<tabTrigger>typography:list_unstyled</tabTrigger>
+	<tabTrigger>b4:typography:list_unstyled</tabTrigger>
 </snippet>

--- a/snippets/content/typography/list_unstyled.sublime-snippet
+++ b/snippets/content/typography/list_unstyled.sublime-snippet
@@ -6,5 +6,5 @@
 	<li>$3</li>
 </ul>
 ]]></content>
-	<tabTrigger>typography:list_unstyled</tabTrigger>
+	<tabTrigger>b4:typography:list_unstyled</tabTrigger>
 </snippet>

--- a/snippets/content/typography/text_muted.sublime-snippet
+++ b/snippets/content/typography/text_muted.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[
 <small class="text-muted">$1</small>
 ]]></content>
-	<tabTrigger>typography:text_muted</tabTrigger>
+	<tabTrigger>b4:typography:text_muted</tabTrigger>
 </snippet>
 
 <!--


### PR DESCRIPTION
Hi there,

I've just uninstalled this package after trying to generate some alerts, radios, and other bootstrap components, because I thought it was not available yet. But they are! It turns out they have different tab triggers.

This is bad. We need to memorize the triggers for each component. It would be nicer to use a pattern, so the autocomplete could be presented and the user can search with the amazing fuzzy search Sublime offers.