### PR TITLE
Updating snippets and adding some tab fields

### DIFF
--- a/snippets/content/figures/figures.sublime-snippet
+++ b/snippets/content/figures/figures.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
 	<content><![CDATA[
 <figure class="figure">
-	<img data-src="$1" class="img-rounded" alt="$2">
-	<figcaption class="figure-caption">$3</figcaption>
+	<img src="$1" class="figure-img img-fluid${2: rounded}" alt="$3">
+	<figcaption class="figure-caption">$4</figcaption>
 </figure>
 ]]></content>
-	<tabTrigger>b4:content:figure</tabTrigger>
+	<tabTrigger>b4:figure</tabTrigger>
 </snippet>

--- a/snippets/content/images/responsive.sublime-snippet
+++ b/snippets/content/images/responsive.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-<img src="$1" class="img-fluid" alt="$2">
+<img src="$1" class="img-fluid${2: img-thumbnail}" alt="${3:Responsive image}">
 ]]></content>
 	<tabTrigger>b4:image:fluid</tabTrigger>
 </snippet>

--- a/snippets/content/tables/table_bordered.sublime-snippet
+++ b/snippets/content/tables/table_bordered.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-<table class="table${1: table-inverse}">
+<table class="table table-bordered${1: table-inverse}${2: table-hover}">
 	<thead>
 		<tr>
 			<th></th>
@@ -13,5 +13,5 @@
 	</tbody>
 </table>
 ]]></content>
-	<tabTrigger>b4:table</tabTrigger>
+	<tabTrigger>b4:table:bordered</tabTrigger>
 </snippet>

--- a/snippets/content/tables/table_head.sublime-snippet
+++ b/snippets/content/tables/table_head.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[
-<table class="table${1: table-inverse}">
-	<thead>
+<table class="table">
+	<thead class="thead-${1:default}${2:inverse}">
 		<tr>
 			<th></th>
 		</tr>
@@ -13,5 +13,5 @@
 	</tbody>
 </table>
 ]]></content>
-	<tabTrigger>b4:table</tabTrigger>
+	<tabTrigger>b4:table:head</tabTrigger>
 </snippet>

--- a/snippets/content/tables/table_hover.sublime-snippet
+++ b/snippets/content/tables/table_hover.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-<table class="table${1: table-inverse}">
+<table class="table table-hover${1: table-inverse}">
 	<thead>
 		<tr>
 			<th></th>
@@ -13,5 +13,5 @@
 	</tbody>
 </table>
 ]]></content>
-	<tabTrigger>b4:table</tabTrigger>
+	<tabTrigger>b4:table:hover</tabTrigger>
 </snippet>

--- a/snippets/content/tables/table_responsive.sublime-snippet
+++ b/snippets/content/tables/table_responsive.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-<table class="table${1: table-inverse}">
+<table class="table table-responsive${1: table-inverse}">
 	<thead>
 		<tr>
 			<th></th>
@@ -13,5 +13,5 @@
 	</tbody>
 </table>
 ]]></content>
-	<tabTrigger>b4:table</tabTrigger>
+	<tabTrigger>b4:table:responsive</tabTrigger>
 </snippet>

--- a/snippets/content/tables/table_small.sublime-snippet
+++ b/snippets/content/tables/table_small.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-<table class="table${1: table-inverse}">
+<table class="table table-sm${1: table-inverse}${2: table-hover}">
 	<thead>
 		<tr>
 			<th></th>
@@ -13,5 +13,5 @@
 	</tbody>
 </table>
 ]]></content>
-	<tabTrigger>b4:table</tabTrigger>
+	<tabTrigger>b4:table:small</tabTrigger>
 </snippet>

--- a/snippets/content/tables/table_striped.sublime-snippet
+++ b/snippets/content/tables/table_striped.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-<table class="table${1: table-inverse}">
+<table class="table table-striped${1: table-inverse}${2: table-hover}">
 	<thead>
 		<tr>
 			<th></th>
@@ -13,5 +13,5 @@
 	</tbody>
 </table>
 ]]></content>
-	<tabTrigger>b4:table</tabTrigger>
+	<tabTrigger>b4:table:striped</tabTrigger>
 </snippet>

--- a/snippets/content/typography/blockquote.sublime-snippet
+++ b/snippets/content/typography/blockquote.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
 	<content><![CDATA[
 <blockquote class="blockquote">
-	<p>${1:Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.}</p>
-	<footer>${2:Someone famous in} <cite title="${3:Source Title}">${3:Source Title}</cite></footer>
+	<p class="mb-0">${1:Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.}</p>
+	<footer class="blockquote-footer">${2:Someone famous in} <cite title="${3:Source Title}">${3:Source Title}</cite></footer>
 </blockquote>
 ]]></content>
-	<tabTrigger>b4:typography:blockquotes</tabTrigger>
+	<tabTrigger>b4:blockquote</tabTrigger>
 </snippet>

--- a/snippets/content/typography/blockquote_reserve.sublime-snippet
+++ b/snippets/content/typography/blockquote_reserve.sublime-snippet
@@ -1,9 +1,0 @@
-<snippet>
-	<content><![CDATA[
-<blockquote class="blockquote blockquote-reverse">
-	<p>${1:Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.}</p>
-	<footer>${2:Someone famous in} <cite title="${3:Source Title}">${3:Source Title}</cite></footer>
-</blockquote>
-]]></content>
-	<tabTrigger>b4:typography:blockquotes_reverse</tabTrigger>
-</snippet>

--- a/snippets/content/typography/description_lists.sublime-snippet
+++ b/snippets/content/typography/description_lists.sublime-snippet
@@ -1,29 +1,29 @@
 <snippet>
 	<content><![CDATA[
-<dt class="col-sm-3">${1:Description lists}</dt>
-<dl class="dl-horizontal">
+<dl class="row">
+	<dt class="col-sm-3">${1:Description lists}</dt>
 	<dd class="col-sm-9">${2:A description list is perfect for defining terms.}</dd>
 
 	<dt class="col-sm-3">${3:Euismod}</dt>
-	<dd class="col-sm-9">${4:Vestibulum id ligula porta felis euismod semper eget lacinia odio sem nec elit.}</dd>
-
-	<dd class="col-sm-9 col-sm-offset-3">${5:Donec id elit non mi porta gravida at eget metus.}</dd>
+	<dd class="col-sm-9">
+		<p>${4:Vestibulum id ligula porta felis euismod semper eget lacinia odio sem nec elit.}</p>
+		<p>${5:Donec id elit non mi porta gravida at eget metus.}</p>
+	</dd>
 
 	<dt class="col-sm-3">${6:Malesuada porta}</dt>
 	<dd class="col-sm-9">${7:Etiam porta sem malesuada magna mollis euismod.}</dd>
 
 	<dt class="col-sm-3 text-truncate">${8:Truncated term is truncated}</dt>
 	<dd class="col-sm-9">${9:Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.}</dd>
+
+	<dt class="col-sm-3">${10:Nesting}</dt>
+	<dd class="col-sm-9">
+		<dl class="row">
+			<dt class="col-sm-4">${11:Nested definition list}</dt>
+			<dd class="col-sm-8">${12:Aenean posuere, tortor sed cursus feugiat, nunc augue blandit nunc.}</dd>
+		</dl>
+	</dd>
 </dl>
 ]]></content>
-	<tabTrigger>b4:typography:disabled_list</tabTrigger>
+	<tabTrigger>b4:description_list</tabTrigger>
 </snippet>
-
-<!--
-
-
-
-
-
-
--->

--- a/snippets/content/typography/display_heading.sublime-snippet
+++ b/snippets/content/typography/display_heading.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[
 <h1 class="display-${1:1|2|3|4}">$2</h1>
 ]]></content>
-	<tabTrigger>b4:typography:display_heading</tabTrigger>
+	<tabTrigger>b4:display_heading</tabTrigger>
 </snippet>

--- a/snippets/content/typography/lead.sublime-snippet
+++ b/snippets/content/typography/lead.sublime-snippet
@@ -4,5 +4,5 @@
     ${1:Lorem ipsum dolor sit amet, consectetur adipisicing elit. Integer posuere erat a ante.}
 </p>'
 ]]></content>
-	<tabTrigger>b4:typography:lead</tabTrigger>
+	<tabTrigger>b4:lead</tabTrigger>
 </snippet>

--- a/snippets/content/typography/list_inline.sublime-snippet
+++ b/snippets/content/typography/list_inline.sublime-snippet
@@ -1,10 +1,10 @@
 <snippet>
 	<content><![CDATA[
 <ul class="list-inline">
-	<li>$1</li>
-	<li>$2</li>
-	<li>$3</li>
+	<li class="list-inline-item">$1</li>
+	<li class="list-inline-item">$2</li>
+	<li class="list-inline-item">$3</li>
 </ul>
 ]]></content>
-	<tabTrigger>b4:typography:list_unstyled</tabTrigger>
+	<tabTrigger>b4:list_inline</tabTrigger>
 </snippet>

--- a/snippets/content/typography/list_unstyled.sublime-snippet
+++ b/snippets/content/typography/list_unstyled.sublime-snippet
@@ -6,5 +6,5 @@
 	<li>$3</li>
 </ul>
 ]]></content>
-	<tabTrigger>b4:typography:list_unstyled</tabTrigger>
+	<tabTrigger>b4:list_unstyled</tabTrigger>
 </snippet>

--- a/snippets/content/typography/text_muted.sublime-snippet
+++ b/snippets/content/typography/text_muted.sublime-snippet
@@ -2,58 +2,5 @@
 	<content><![CDATA[
 <small class="text-muted">$1</small>
 ]]></content>
-	<tabTrigger>b4:typography:text_muted</tabTrigger>
+	<tabTrigger>b4:text_muted</tabTrigger>
 </snippet>
-
-<!--
-
-<h1 class="display-${1:1|2|3|4}">$2</h1>
-
-<p class="lead">
-  ${1:Lorem ipsum dolor sit amet, consectetur adipisicing elit. Integer posuere erat a ante.}
-</p>'
-
-
-<blockquote class="blockquote">
-  <p>${1:Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.}</p>
-  <footer>${2:Someone famous in} <cite title="${3:Source Title}">${3:Source Title}</cite></footer>
-</blockquote>
-
-
-<blockquote class="blockquote blockquote-reverse">
-  <p>${1:Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.}</p>
-  <footer>${2:Someone famous in} <cite title="${3:Source Title}">${3:Source Title}</cite></footer>
-</blockquote>
-
-
-<ul class="list-unstyled">
-  <li>$1</li>
-  <li>$2</li>
-  <li>$3</li>
-</ul>
-
-
-<ul class="list-inline">
-  <li>$1</li>
-  <li>$2</li>
-  <li>$3</li>
-</ul>
-
-
-<dt class="col-sm-3">${1:Description lists}</dt>
-<dl class="dl-horizontal">
-  <dd class="col-sm-9">${2:A description list is perfect for defining terms.}</dd>
-
-  <dt class="col-sm-3">${3:Euismod}</dt>
-  <dd class="col-sm-9">${4:Vestibulum id ligula porta felis euismod semper eget lacinia odio sem nec elit.}</dd>
-
-  <dd class="col-sm-9 col-sm-offset-3">${5:Donec id elit non mi porta gravida at eget metus.}</dd>
-
-  <dt class="col-sm-3">${6:Malesuada porta}</dt>
-  <dd class="col-sm-9">${7:Etiam porta sem malesuada magna mollis euismod.}</dd>
-
-  <dt class="col-sm-3 text-truncate">${8:Truncated term is truncated}</dt>
-  <dd class="col-sm-9">${9:Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.}</dd>
-</dl>
-
--->

--- a/snippets/layout/media/bottom.sublime-snippet
+++ b/snippets/layout/media/bottom.sublime-snippet
@@ -1,11 +1,11 @@
 <snippet>
 	<content><![CDATA[
 <div class="media">
-	<img class="d-flex align-self-end mr-3" src="..." alt="Generic placeholder image">
+	<img class="d-flex align-self-end mr-3" src="$1" alt="${2:Generic placeholder image}">
 	<div class="media-body">
-		<h5 class="mt-0">Bottom-aligned media</h5>
-		<p>Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.</p>
-		<p class="mb-0">Donec sed odio dui. Nullam quis risus eget urna mollis ornare vel eu leo. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
+		<h5 class="mt-0">${3:Bottom-aligned media}</h5>
+		<p>${4:Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.}</p>
+		<p class="mb-0">${5:Donec sed odio dui. Nullam quis risus eget urna mollis ornare vel eu leo. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.}</p>
 	</div>
 </div>
 ]]></content>

--- a/snippets/layout/media/center.sublime-snippet
+++ b/snippets/layout/media/center.sublime-snippet
@@ -1,11 +1,11 @@
 <snippet>
 	<content><![CDATA[
 <div class="media">
-	<img class="d-flex align-self-center mr-3" src="..." alt="Generic placeholder image">
+	<img class="d-flex align-self-center mr-3" src="$1" alt="${2:Generic placeholder image}">
 	<div class="media-body">
-		<h5 class="mt-0">Center-aligned media</h5>
-		<p>Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.</p>
-		<p class="mb-0">Donec sed odio dui. Nullam quis risus eget urna mollis ornare vel eu leo. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
+		<h5 class="mt-0">${3:Center-aligned media}</h5>
+		<p>${4:Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.}</p>
+		<p class="mb-0">${5:Donec sed odio dui. Nullam quis risus eget urna mollis ornare vel eu leo. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.}</p>
 	</div>
 </div>
 ]]></content>

--- a/snippets/layout/media/list.sublime-snippet
+++ b/snippets/layout/media/list.sublime-snippet
@@ -2,24 +2,24 @@
 	<content><![CDATA[
 <ul class="list-unstyled">
 	<li class="media">
-		<img class="d-flex mr-3" src="..." alt="Generic placeholder image">
+		<img class="d-flex mr-3" src="$1" alt="${2:Generic placeholder image}">
 		<div class="media-body">
-			<h5 class="mt-0 mb-1">List-based media object</h5>
-			Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+			<h5 class="mt-0 mb-1">${3:List-based media object}</h5>
+			${4:Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.}
 		</div>
 	</li>
 	<li class="media my-4">
-		<img class="d-flex mr-3" src="..." alt="Generic placeholder image">
+		<img class="d-flex mr-3" src="$5" alt="${6:Generic placeholder image}">
 		<div class="media-body">
-			<h5 class="mt-0 mb-1">List-based media object</h5>
-			Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+			<h5 class="mt-0 mb-1">${7:List-based media object}</h5>
+			${8:Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.}
 		</div>
 	</li>
 	<li class="media">
-		<img class="d-flex mr-3" src="..." alt="Generic placeholder image">
+		<img class="d-flex mr-3" src="$9" alt="${10:Generic placeholder image}">
 		<div class="media-body">
-			<h5 class="mt-0 mb-1">List-based media object</h5>
-			Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+			<h5 class="mt-0 mb-1">${11:List-based media object}</h5>
+			${12:Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.}
 		</div>
 	</li>
 </ul>

--- a/snippets/layout/media/media.sublime-snippet
+++ b/snippets/layout/media/media.sublime-snippet
@@ -1,10 +1,10 @@
 <snippet>
 	<content><![CDATA[
 <div class="media">
-	<img class="d-flex mr-3" src="..." alt="Generic placeholder image">
+	<img class="d-flex mr-3" src="$1" alt="${2:Generic placeholder image}">
 	<div class="media-body">
-		<h5 class="mt-0">Media heading</h5>
-		Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+		<h5 class="mt-0">${3:Media heading}</h5>
+		${4:Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.}
 	</div>
 </div>
 ]]></content>

--- a/snippets/layout/media/right.sublime-snippet
+++ b/snippets/layout/media/right.sublime-snippet
@@ -2,10 +2,10 @@
 	<content><![CDATA[
 <div class="media">
 	<div class="media-body">
-		<h5 class="mt-0 mb-1">Media object</h5>
-		Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.
+		<h5 class="mt-0 mb-1">${1:Media object}</h5>
+		${2:Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio, vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec lacinia congue felis in faucibus.}
 	</div>
-	<img class="d-flex ml-3" src="..." alt="Generic placeholder image">
+	<img class="d-flex ml-3" src="$3" alt="${4:Generic placeholder image}">
 </div>
 ]]></content>
 	<tabTrigger>b4:media:right</tabTrigger>

--- a/snippets/template/html5.sublime-snippet
+++ b/snippets/template/html5.sublime-snippet
@@ -1,18 +1,18 @@
 <snippet>
 	<content><![CDATA[
 <!DOCTYPE html>
-<html lang="en">
+<html lang="${1:en}">
 	<head>
 		<!-- Required meta tags -->
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+		<title>${2:Page Title}</title>
 
 		<!-- Bootstrap CSS -->
 		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
 	</head>
-
 	<body>
-		<h1>Hello, world!</h1>
+		${3:<h1>${4:Hello, world!}</h1>}$0
 
 		<!-- Optional JavaScript -->
 		<!-- jQuery first, then Popper.js, then Bootstrap JS -->


### PR DESCRIPTION
Hey there!

I've made some changes in some snippets located at
```
snippets/
├── content/
│   ├── figures/
│   ├── images/
│   ├── tables/
│   └── typography/
└── layout/
    ├── media/
└── template/
    ├── html5.sublime-snippet
```

- Basically, it's just a revision to make sure the content of those folders are even with bootstrap 4.0.0-beta documentation;
- Fixed duplicated tab triggers;
- Removed undocumented snippets;
- Added lots of tab fields;
- Some tab triggers have been changed to make it easier. For example, `b4:content:figure` now it's just `b4:figure`, `b4:typography:blockquotes` now it's `b4:blockquote`. The folder structure remains the same, this is just to make the autocomplete more clean, because the user don't really need to know the section and subsection of each snippet.

I intend keep this work inside the components folder.